### PR TITLE
Add spaces redirect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/09/03 22:33:20 by irychkov          #+#    #+#              #
-#    Updated: 2024/09/08 00:49:59 by irychkov         ###   ########.fr        #
+#    Updated: 2024/09/09 22:50:25 by irychkov         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -14,7 +14,7 @@ NAME = minishell
 
 SRCS = src/main.c src/ft_split_args.c \
 		src/init_pipes.c src/init_cmd.c \
-		src/parse_redirect.c \
+		src/ft_update_args.c src/parse_redirect.c \
 		src/exec_cmd.c src/exec_pipes.c \
 		src/free.c \
 		src/test_split.c src/test_parse_redirect.c

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/05 15:44:35 by omartela          #+#    #+#             */
-/*   Updated: 2024/09/08 00:50:23 by irychkov         ###   ########.fr       */
+/*   Updated: 2024/09/09 23:01:40 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,9 +48,10 @@ typedef struct s_pipes
 }	t_pipes;
 
 // main functions
-char	**ft_split_args(char const *s, char c);
-int		init_cmd(t_cmd **cmd, const char *command, char **envp);
+char	**ft_split_args(char *s, char c);
+int		init_cmd(t_cmd **cmd, char *command, char **envp);
 void	init_num_cmds(t_shell *sh);
+char	*ft_add_spaces(char *s);
 int		parse_redirections(t_cmd *cmd, char **args);
 int		init_pipes(t_pipes *pipes, int num_cmds);
 int		execute_pipes(t_shell *sh);

--- a/src/ft_split_args.c
+++ b/src/ft_split_args.c
@@ -6,7 +6,7 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/04 12:44:50 by irychkov          #+#    #+#             */
-/*   Updated: 2024/09/04 22:34:36 by irychkov         ###   ########.fr       */
+/*   Updated: 2024/09/09 23:04:30 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ The function allocates memory for the array and for each string.
 The array is NULL-terminated. If the allocation fails, the function returns NULL.
 */
 
-static size_t	ft_strcounter(char const *s, char c)
+static size_t	ft_strcounter(char *s, char c)
 {
 	size_t	elements;
 	int		in_quotes;
@@ -49,7 +49,7 @@ static size_t	ft_strcounter(char const *s, char c)
 	return (elements);
 }
 
-static size_t	len_without_quotes(const char *str, size_t len)
+static size_t	len_without_quotes(char *str, size_t len)
 {
 	size_t	i;
 	size_t	count;
@@ -65,7 +65,7 @@ static size_t	len_without_quotes(const char *str, size_t len)
 	return (count);
 }
 
-static char	*copy_without_quotes(const char *start, size_t len)
+static char	*copy_without_quotes(char *start, size_t len)
 {
 	size_t	i;
 	size_t	j;
@@ -88,9 +88,9 @@ static char	*copy_without_quotes(const char *start, size_t len)
 	return (result);
 }
 
-static char	**ft_helper(char const *s, char c, size_t i, char **result)
+static char	**ft_helper(char *s, char c, size_t i, char **result)
 {
-	const char	*start;
+	char	*start;
 	int			in_quotes;
 	char		quote_type;
 
@@ -125,7 +125,7 @@ static char	**ft_helper(char const *s, char c, size_t i, char **result)
 	return (result);
 }
 
-char	**ft_split_args(char const *s, char c)
+char	**ft_split_args(char *s, char c)
 {
 	size_t		i;
 	char		**result;

--- a/src/ft_update_args.c
+++ b/src/ft_update_args.c
@@ -1,0 +1,113 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_update_args.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/09/09 14:04:53 by irychkov          #+#    #+#             */
+/*   Updated: 2024/09/09 16:22:29 by irychkov         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+/* #include "minishell.h" */
+#include "..//libft/libft.h"
+#include <stdio.h>
+
+size_t	ft_strlen(const char	*str)
+{
+	size_t	i;
+
+	i = 0;
+	while (str[i] != '\0')
+	{
+		i++;
+	}
+	return (i);
+}
+
+static size_t	ft_redirect_counter(char const *s)
+{
+	size_t	spaces;
+	int		in_quotes;
+	char	quote_type;
+
+	spaces = 0;
+	in_quotes = 0;
+	while (*s)
+	{
+		if (((*s == '<') || (*s == '>')) && !in_quotes)
+		{
+			spaces++;
+			while ((*s == '<') || (*s == '>'))
+				s++;
+			continue ;
+		}
+		if ((*s == '\'' || *s == '\"') && !in_quotes)
+		{
+			in_quotes = 1;
+			quote_type = *s;
+		}
+		else if (in_quotes && *s == quote_type)
+			in_quotes = 0;
+		s++;
+	}
+	return (spaces);
+}
+
+static char	*ft_add_spaces(char const *s)
+{
+	size_t	len;
+	size_t	spaces_needed;
+	char	*new_str;
+	char	*dest;
+	int		in_quotes;
+	char	quote_type;
+
+	in_quotes = 0;
+	len = ft_strlen(s);
+	spaces_needed = ft_redirect_counter(s);
+	new_str = malloc(len + spaces_needed + 1); // protect
+	dest = new_str;
+	if (!new_str)
+		return NULL;
+	while (*s)
+	{
+		if (((*s == '<') || (*s == '>')) && !in_quotes)
+		{
+			if (dest > new_str && *(dest - 1) != ' ' && *(dest - 1) != '<' && *(dest - 1) != '>')
+				*dest++ = ' ';
+			*dest++ = *s;
+			if (*(s + 1) && *(s + 1) != ' ' && *(s + 1) != '<' && *(s + 1) != '>')
+				*dest++ = ' ';
+		}
+		else
+		{
+			if ((*s == '\'' || *s == '\"') && !in_quotes)
+			{
+				in_quotes = 1;
+				quote_type = *s;
+			}
+			else if (in_quotes && *s == quote_type)
+				in_quotes = 0;
+			*dest++ = *s;
+		}
+		s++;
+	}
+
+	*dest = '\0';
+	return (new_str);
+}
+
+int	main(void)
+{
+	char str[] = "<<<>><cat'<sda,d>'<><<>";
+	char *new_str = ft_add_spaces(str);
+	if (new_str)
+	{
+		printf("Original string: \"%s\"\n", str);
+		printf("Modified string: \"%s\"\n", new_str);
+		free(new_str);
+	}
+	return 0;
+}

--- a/src/ft_update_args.c
+++ b/src/ft_update_args.c
@@ -6,7 +6,7 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/09 14:04:53 by irychkov          #+#    #+#             */
-/*   Updated: 2024/09/09 16:22:29 by irychkov         ###   ########.fr       */
+/*   Updated: 2024/09/09 16:30:59 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -109,5 +109,5 @@ int	main(void)
 		printf("Modified string: \"%s\"\n", new_str);
 		free(new_str);
 	}
-	return 0;
+	return (0);
 }

--- a/src/ft_update_args.c
+++ b/src/ft_update_args.c
@@ -6,27 +6,13 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/09 14:04:53 by irychkov          #+#    #+#             */
-/*   Updated: 2024/09/09 16:30:59 by irychkov         ###   ########.fr       */
+/*   Updated: 2024/09/09 23:13:04 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-/* #include "minishell.h" */
-#include "..//libft/libft.h"
-#include <stdio.h>
+#include "minishell.h"
 
-size_t	ft_strlen(const char	*str)
-{
-	size_t	i;
-
-	i = 0;
-	while (str[i] != '\0')
-	{
-		i++;
-	}
-	return (i);
-}
-
-static size_t	ft_redirect_counter(char const *s)
+static size_t	ft_redirect_counter(char *s)
 {
 	size_t	spaces;
 	int		in_quotes;
@@ -55,7 +41,7 @@ static size_t	ft_redirect_counter(char const *s)
 	return (spaces);
 }
 
-static char	*ft_add_spaces(char const *s)
+char	*ft_add_spaces(char *s)
 {
 	size_t	len;
 	size_t	spaces_needed;
@@ -70,7 +56,7 @@ static char	*ft_add_spaces(char const *s)
 	new_str = malloc(len + spaces_needed + 1); // protect
 	dest = new_str;
 	if (!new_str)
-		return NULL;
+		return (NULL);
 	while (*s)
 	{
 		if (((*s == '<') || (*s == '>')) && !in_quotes)
@@ -94,20 +80,6 @@ static char	*ft_add_spaces(char const *s)
 		}
 		s++;
 	}
-
 	*dest = '\0';
 	return (new_str);
-}
-
-int	main(void)
-{
-	char str[] = "<<<>><cat'<sda,d>'<><<>";
-	char *new_str = ft_add_spaces(str);
-	if (new_str)
-	{
-		printf("Original string: \"%s\"\n", str);
-		printf("Modified string: \"%s\"\n", new_str);
-		free(new_str);
-	}
-	return (0);
 }

--- a/src/init_cmd.c
+++ b/src/init_cmd.c
@@ -6,7 +6,7 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/04 15:29:22 by irychkov          #+#    #+#             */
-/*   Updated: 2024/09/08 00:41:22 by irychkov         ###   ########.fr       */
+/*   Updated: 2024/09/09 23:10:50 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,8 +45,11 @@ void	init_num_cmds(t_shell *sh)
 	sh->num_cmds = i;
 }
 
-int	init_cmd(t_cmd **cmd, const char *command, char **envp)
+int	init_cmd(t_cmd **cmd, char *command, char **envp)
 {
+	char *temp;
+
+
 	*cmd = malloc(sizeof(t_cmd));
 	if (!*cmd)
 	{
@@ -58,7 +61,15 @@ int	init_cmd(t_cmd **cmd, const char *command, char **envp)
 	(*cmd)->infile = NULL;
 	(*cmd)->outfile = NULL;
 	(*cmd)->append = 0;
-	(*cmd)->args = ft_split_args(command, ' ');
+	(*cmd)->args = NULL;
+	temp = ft_add_spaces(command);
+	if (!(temp))
+	{
+		perror("malloc"); //free all
+		free(*cmd);
+		return (1);
+	}
+	(*cmd)->args = ft_split_args(temp, ' ');
 	if (!(*cmd)->args)
 	{
 		perror("ft_split_args"); //free all

--- a/src/test_parse_redirect.c
+++ b/src/test_parse_redirect.c
@@ -6,7 +6,7 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/04 22:30:45 by irychkov          #+#    #+#             */
-/*   Updated: 2024/09/05 13:10:14 by irychkov         ###   ########.fr       */
+/*   Updated: 2024/09/09 23:19:45 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,9 +23,9 @@ void	print_command(t_cmd *cmd)
 		printf("Error: cmd->args is NULL\n");
 		return;
 	}
-	printf("Command: ");
+	printf("Command: \n");
 	for (int i = 0; cmd->args[i] != NULL; i++) {
-		printf("%s ", cmd->args[i]);
+		printf("cmd[%d] %s\n", i, cmd->args[i]);
 	}
 	printf("\n");
 


### PR DESCRIPTION
Implemented a function for parsing redirects. The function adds spaces in a case ex. (before: "<dir ls  | cat>>out" after: "< dir ls | cat >> out"). Next step is improving splitting for pipes. We don't  handle cases like "ls||cat>>out"